### PR TITLE
Adjust restraints

### DIFF
--- a/scripts/calculate_dG.py
+++ b/scripts/calculate_dG.py
@@ -8,14 +8,13 @@ from tqdm import tqdm
 from typing import Tuple
 import os
 
-from openmm import unit
-from openmm import unit
+# from openmm import unit
+# from openmm import unit
 from openmm import app
 from openmm import Platform
-from openmm import LangevinIntegrator
-from openmmml import MLPotential
-from openmm.app import Simulation
-from openmmtools.constants import kB
+# from openmm import LangevinIntegrator
+# from openmm.app import Simulation
+# from openmmtools.constants import kB
 
 import mdtraj as md
 from pymbar import MBAR
@@ -83,5 +82,6 @@ r = mbar.compute_free_energy_differences()["Delta_f"][0][-1]
 
 print("##################################################")
 print(f"Computed dG: {r*0.5922:.2f} kcal/mol") # convert from kBT to kcal/mol
-print(f"Experiment dG: {experiment:.2f} kcal/mol")
+print(f"Experimental dG: {experiment:.2f} kcal/mol")
+print(f"Error: {(experiment - r*0.5922):.2f} kcal/mol")
 print("##################################################")

--- a/scripts/run_equ_sim.py
+++ b/scripts/run_equ_sim.py
@@ -80,6 +80,7 @@ sim = get_sim(solv_system=solv_system,
             platform=platform,
             bond_restraints=True,
             angle_restraints=True,
+            control_param=4,
             device_index=device_index)
 
 ################################################ data collection setup ###############################################################


### PR DESCRIPTION
## Description
Bond and angle restraints were adjusted. Both are now controlled by a `control_param`, which depending on the value, turns on/off the restraint; either respectively to the lambda_value (`control_param = 1`) or in a faster manner (e.g. given a `lambda scheme = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]` and a `control_param = 2`, the restraint will be turned on according to the following scheme: `[0.0, 0.0, 0.0, 0.0, 0.2, 0.6, 1.0]`

## Status
- [x] Ready to go